### PR TITLE
Add configurations to SDK and CLI

### DIFF
--- a/cmd/appcreds.go
+++ b/cmd/appcreds.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -135,23 +135,23 @@ func newConfigurationCreateCmd() *cobra.Command {
 
 func newConfigurationGetCmd() *cobra.Command {
 	flags := configGetCmd.Flags()
-	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to to add the configurations")
-	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment to add the configurations")
-	flags.StringVarP(&configID, "configurations", "a", "", "ID of the configuration")
+	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to to get the configuration")
+	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment to get the configuration")
+	flags.StringVarP(&configID, "configuration", "i", "", "ID of the configuration")
 	return configGetCmd
 }
 
 func newConfigurationDeleteCmd() *cobra.Command {
 	flags := configDeleteCmd.Flags()
-	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to to add the configurations")
-	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment to add the configurations")
-	flags.StringVarP(&configID, "configurations", "a", "", "ID of the configuration")
+	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to to delete the configurations")
+	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment to delete the configurations")
+	flags.StringVarP(&configID, "configuration", "i", "", "ID of the configuration")
 	return configDeleteCmd
 }
 
 func newConfigurationListCmd() *cobra.Command {
 	flags := configListCmd.Flags()
-	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to to add the configurations")
-	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment to add the configurations")
+	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to to list the configurations")
+	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment to list the configurations")
 	return configListCmd
 }

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -1,0 +1,157 @@
+// Copyright 2018 Kaleido, a ConsenSys business
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	kld "github.com/kaleido-io/kaleido-sdk-go/kaleido"
+	"github.com/spf13/cobra"
+)
+
+var configCreateCmd = &cobra.Command{
+	Use:   "configuration",
+	Short: "Create configurations",
+	Run: func(cmd *cobra.Command, args []string) {
+		validateConsortiumID("configurations")
+		validateEnvironmentID("configurations")
+		validateMembershipID("configurations")
+		client := getNewClient()
+
+		if name == "" {
+			fmt.Println("Missing required parameter: --name for the configuration to create")
+			os.Exit(1)
+		}
+
+		if configType == "" {
+			fmt.Println("Missing required parameter: --type for the configuration type to create")
+			os.Exit(1)
+		}
+
+		if detailsFile == "" {
+			fmt.Println("Missing required parameter: --file for the JSON details of the configuration type to create")
+			os.Exit(1)
+		}
+
+		var details map[string]interface{}
+		b, err := ioutil.ReadFile(detailsFile)
+		if err != nil {
+			fmt.Printf("Unable to open file '%s': %s", detailsFile, err)
+			os.Exit(1)
+		}
+		err = json.Unmarshal(b, &details)
+		if err != nil {
+			fmt.Printf("Unable to parse JSON in file '%s': %s", detailsFile, err)
+			os.Exit(1)
+		}
+
+		configurations := kld.NewConfiguration(name, membershipID, configType, details)
+		res, err := client.CreateConfiguration(consortiumID, environmentID, &configurations)
+		validateCreationResponse(res, err, "configurations")
+	},
+}
+
+var configGetCmd = &cobra.Command{
+	Use:   "configuration",
+	Short: "Get configurations",
+	Run: func(cmd *cobra.Command, args []string) {
+		validateConsortiumID("configurations")
+		validateEnvironmentID("configurations")
+
+		if configID == "" {
+			fmt.Println("Missing required parameter: --id for the configuration to get")
+			os.Exit(1)
+		}
+
+		client := getNewClient()
+		var configuration kld.Configuration
+		res, err := client.GetConfiguration(consortiumID, environmentID, configID, &configuration)
+		validateGetResponse(res, err, "configurations")
+	},
+}
+
+var configDeleteCmd = &cobra.Command{
+	Use:   "configuration",
+	Short: "Delete configurations",
+	Run: func(cmd *cobra.Command, args []string) {
+		validateConsortiumID("configurations")
+		validateEnvironmentID("configurations")
+
+		if configID == "" {
+			fmt.Println("Missing required parameter: --id for the configuration to delete")
+			os.Exit(1)
+		}
+
+		client := getNewClient()
+		res, err := client.DeleteConfiguration(consortiumID, environmentID, configID)
+		validateDeletionResponse(res, err, "configurations")
+	},
+}
+
+var configListCmd = &cobra.Command{
+	Use:   "configuration",
+	Short: "List the configurations",
+	Run: func(cmd *cobra.Command, args []string) {
+		validateConsortiumID("configurations")
+		validateEnvironmentID("configurations")
+		client := getNewClient()
+		var configurations []kld.Configuration
+		_, err := client.ListConfigurations(consortiumID, environmentID, &configurations)
+		if err != nil {
+			fmt.Printf("Failed to list configurations. %v\n", err)
+			os.Exit(1)
+		}
+
+		encoded, _ := json.Marshal(configurations)
+		fmt.Printf("\n%+v\n", string(encoded))
+	},
+}
+
+func newConfigurationCreateCmd() *cobra.Command {
+	flags := configCreateCmd.Flags()
+	flags.StringVarP(&name, "name", "n", "", "Name of the configuration")
+	flags.StringVarP(&configType, "type", "t", "", "Type of the configuration")
+	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to to add the configurations")
+	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment to add the configurations")
+	flags.StringVarP(&membershipID, "membership", "m", "", "ID of the membership to issue the configurations to")
+	flags.StringVarP(&detailsFile, "file", "f", "", "JSON file containing type specific details of the configuration to create")
+	return configCreateCmd
+}
+
+func newConfigurationGetCmd() *cobra.Command {
+	flags := configGetCmd.Flags()
+	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to to add the configurations")
+	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment to add the configurations")
+	flags.StringVarP(&configID, "configurations", "a", "", "ID of the configuration")
+	return configGetCmd
+}
+
+func newConfigurationDeleteCmd() *cobra.Command {
+	flags := configDeleteCmd.Flags()
+	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to to add the configurations")
+	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment to add the configurations")
+	flags.StringVarP(&configID, "configurations", "a", "", "ID of the configuration")
+	return configDeleteCmd
+}
+
+func newConfigurationListCmd() *cobra.Command {
+	flags := configListCmd.Flags()
+	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to to add the configurations")
+	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment to add the configurations")
+	return configListCmd
+}

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright 2020 Kaleido, a ConsenSys business
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -137,7 +137,7 @@ func newConfigurationGetCmd() *cobra.Command {
 	flags := configGetCmd.Flags()
 	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to to get the configuration")
 	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment to get the configuration")
-	flags.StringVarP(&configID, "configuration", "i", "", "ID of the configuration")
+	flags.StringVarP(&configID, "id", "i", "", "ID of the configuration")
 	return configGetCmd
 }
 
@@ -145,7 +145,7 @@ func newConfigurationDeleteCmd() *cobra.Command {
 	flags := configDeleteCmd.Flags()
 	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to to delete the configurations")
 	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment to delete the configurations")
-	flags.StringVarP(&configID, "configuration", "i", "", "ID of the configuration")
+	flags.StringVarP(&configID, "id", "i", "", "ID of the configuration")
 	return configDeleteCmd
 }
 

--- a/cmd/consortium.go
+++ b/cmd/consortium.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (
@@ -21,7 +22,7 @@ import (
 
 var createCmd = &cobra.Command{
 	Use:   "create",
-	Short: "Create various resources: consortium, membership, environment, node, appcreds, invitation",
+	Short: "Create various resources: consortium, membership, environment, node, appcreds, invitation, configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("create command")
 	},
@@ -37,6 +38,7 @@ func newCreateCmd() *cobra.Command {
 	createCmd.AddCommand(newInvitationCreateCmd())
 	createCmd.AddCommand(newCZoneCreateCmd())
 	createCmd.AddCommand(newEZoneCreateCmd())
+	createCmd.AddCommand(newConfigurationCreateCmd())
 
 	return createCmd
 }

--- a/cmd/czone.go
+++ b/cmd/czone.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (
@@ -21,7 +22,7 @@ import (
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
-	Short: "Delete various resources: consortium, membership, environment, node, appcreds",
+	Short: "Delete various resources: consortium, membership, environment, node, appcreds, configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Delete command")
 	},
@@ -36,6 +37,7 @@ func newDeleteCmd() *cobra.Command {
 	deleteCmd.AddCommand(newInvitationDeleteCmd())
 	deleteCmd.AddCommand(newCZoneDeleteCmd())
 	deleteCmd.AddCommand(newEZoneDeleteCmd())
+	deleteCmd.AddCommand(newConfigurationDeleteCmd())
 
 	return deleteCmd
 }

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/ezone.go
+++ b/cmd/ezone.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (
@@ -21,7 +22,7 @@ import (
 
 var getCmd = &cobra.Command{
 	Use:   "get",
-	Short: "Get details of a resource: consortium, membership, environment, node, appcreds, directory",
+	Short: "Get details of a resource: consortium, membership, environment, node, appcreds, directory, configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("get command")
 	},
@@ -37,6 +38,7 @@ func newGetCmd() *cobra.Command {
 	getCmd.AddCommand(newInvitationGetCmd())
 	getCmd.AddCommand(newCZoneGetCmd())
 	getCmd.AddCommand(newEZoneGetCmd())
+	getCmd.AddCommand(newConfigurationGetCmd())
 
 	return getCmd
 }

--- a/cmd/invitation.go
+++ b/cmd/invitation.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (
@@ -21,7 +22,7 @@ import (
 
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List various resources this user account owns: consortium, membership, environment, node, appcreds",
+	Short: "List various resources this user account owns: consortium, membership, environment, node, appcreds, configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("list command")
 	},
@@ -37,6 +38,7 @@ func newListCmd() *cobra.Command {
 	listCmd.AddCommand(newInvitationListCmd())
 	listCmd.AddCommand(newCZoneListCmd())
 	listCmd.AddCommand(newEZoneListCmd())
+	listCmd.AddCommand(newConfigurationListCmd())
 
 	return listCmd
 }

--- a/cmd/membership.go
+++ b/cmd/membership.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (
@@ -88,6 +89,14 @@ var nodeCreateCmd = &cobra.Command{
 
 		client := getNewClient()
 		node := kld.NewNode(name, membershipID, ezoneID)
+
+		node.Size = size
+		node.KmsID = kmsID
+		node.OpsmetricID = opsmetricID
+		node.BackupID = backupID
+		node.NetworkingID = networkingID
+		node.NodeConfigID = nodeConfigID
+
 		res, err := client.CreateNode(consortiumID, environmentID, &node)
 
 		validateCreationResponse(res, err, "node")
@@ -144,6 +153,12 @@ func newNodeCreateCmd() *cobra.Command {
 	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium this node is created under")
 	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment this node is created for")
 	flags.StringVarP(&ezoneID, "zone", "z", "", "ID of the environment deployment zone where this node should be created")
+	flags.StringVarP(&size, "size", "s", "", "Size for the node")
+	flags.StringVarP(&kmsID, "kms-id", "k", "", "KMS config ID to attach to the node")
+	flags.StringVarP(&opsmetricID, "opsmetric-id", "o", "", "Opsmertic config ID to attach to the node")
+	flags.StringVarP(&backupID, "backup-id", "b", "", "Backup config ID to attach to the node")
+	flags.StringVarP(&networkingID, "networking-id", "N", "", "Networking config ID to attach to the node")
+	flags.StringVarP(&nodeConfigID, "node-config-id", "C", "", "Node config ID to attach to the node")
 
 	return nodeCreateCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,14 @@ var region string
 var cloud string
 var multiRegion bool
 var blockPeriod int
+var configType string
+var detailsFile string
+var size string
+var kmsID string
+var opsmetricID string
+var backupID string
+var networkingID string
+var nodeConfigID string
 
 // use for both create, list, get and delete commands
 var consortiumID string
@@ -50,6 +58,7 @@ var serviceID string
 var appCredsID string
 var service string
 var invitationID string
+var configID string
 
 // for delete command
 var deleteID string

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9r
 github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf h1:sh8rkQZavChcmakYiSlqu2425CHyFXLZZnvm7PDpU8M=
 github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
@@ -110,6 +111,7 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
@@ -411,6 +413,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/kaleido/configuration.go
+++ b/kaleido/configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright 2020 Kaleido, a ConsenSys business
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/configuration.go
+++ b/kaleido/configuration.go
@@ -1,0 +1,62 @@
+// Copyright 2018 Kaleido, a ConsenSys business
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kaleido
+
+import (
+	"fmt"
+
+	resty "gopkg.in/resty.v1"
+)
+
+const (
+	configurationsBasePath = "/consortia/%s/environments/%s/configurations"
+)
+
+type Configuration struct {
+	ID           string                 `json:"_id,omitempty"`
+	Name         string                 `json:"name,omitempty"`
+	MembershipID string                 `json:"membership_id,omitempty"`
+	Type         string                 `json:"type,omitempty"`
+	Details      map[string]interface{} `json:"details"`
+}
+
+func NewConfiguration(name, membershipID, configType string, details map[string]interface{}) Configuration {
+	return Configuration{
+		Name:         name,
+		MembershipID: membershipID,
+		Type:         configType,
+		Details:      details,
+	}
+}
+
+func (c *KaleidoClient) CreateConfiguration(consortium, envID string, config *Configuration) (*resty.Response, error) {
+	path := fmt.Sprintf(configurationsBasePath, consortium, envID)
+	return c.Client.R().SetResult(config).SetBody(config).Post(path)
+}
+
+func (c *KaleidoClient) DeleteConfiguration(consortium, envID, configID string) (*resty.Response, error) {
+	path := fmt.Sprintf(configurationsBasePath+"/%s", consortium, envID, configID)
+	return c.Client.R().Delete(path)
+}
+
+func (c *KaleidoClient) ListConfigurations(consortium, envID string, resultBox *[]Configuration) (*resty.Response, error) {
+	path := fmt.Sprintf(configurationsBasePath, consortium, envID)
+	return c.Client.R().SetResult(resultBox).Get(path)
+}
+
+func (c *KaleidoClient) GetConfiguration(consortiumID, envID, configID string, resultBox *Configuration) (*resty.Response, error) {
+	path := fmt.Sprintf(configurationsBasePath+"/%s", consortiumID, envID, configID)
+	return c.Client.R().SetResult(resultBox).Get(path)
+}

--- a/kaleido/configuration_test.go
+++ b/kaleido/configuration_test.go
@@ -1,0 +1,103 @@
+// Copyright 2018 Kaleido, a ConsenSys business
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package kaleido
+
+import (
+	"testing"
+
+	"github.com/nbio/st"
+	gock "gopkg.in/h2non/gock.v1"
+)
+
+var mockConfigurationCreatePayload = map[string]interface{}{
+	"name":          "configName",
+	"membership_id": "member1",
+	"type":          "node_config",
+	"details": map[string]interface{}{
+		"config_specific": "details",
+	},
+}
+
+var mockConfiguration = Configuration{
+	ID:           "zzstcszriw",
+	Name:         "configName",
+	MembershipID: "member1",
+	Type:         "node_config",
+	Details: map[string]interface{}{
+		"config_specific": "details",
+	},
+}
+
+var mockConfigurations = []Configuration{mockConfiguration}
+
+func TestConfigurationCreate(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	gock.New("http://example.com").
+		Post("/api/v1/consortia/c1/environments/env1/configurations").
+		MatchType("json").
+		JSON(mockConfigurationCreatePayload).
+		Reply(201).
+		JSON(mockConfiguration)
+
+	client := NewClient("http://example.com/api/v1", "KALEIDO_API_KEY")
+	var config = NewConfiguration("configName", "member1", "node_config", map[string]interface{}{
+		"config_specific": "details",
+	})
+	_, err := client.CreateConfiguration("c1", "env1", &config)
+	st.Expect(t, err, nil)
+	st.Expect(t, gock.IsDone(), true)
+}
+
+func TestConfigurationGet(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://example.com").
+		Get("/api/v1/consortia/c1/environments/env1/configurations/configuration1").
+		Reply(200).
+		JSON(mockConfiguration)
+
+	client := NewClient("http://example.com/api/v1", "KALEIDO_API_KEY")
+	_, err := client.GetConfiguration("c1", "env1", "configuration1", &Configuration{})
+	st.Expect(t, err, nil)
+	st.Expect(t, gock.IsDone(), true)
+}
+
+func TestConfigurationList(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://example.com").
+		Get("/api/v1/consortia/c1/environments/env1/configurations").
+		Reply(200).
+		JSON(mockConfigurations)
+
+	client := NewClient("http://example.com/api/v1", "KALEIDO_API_KEY")
+	_, err := client.ListConfigurations("c1", "env1", &[]Configuration{})
+	st.Expect(t, err, nil)
+	st.Expect(t, gock.IsDone(), true)
+}
+
+func TestConfigurationDelete(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://example.com").
+		Delete("/api/v1/consortia/c1/environments/env1/configurations/configuration1").
+		Reply(202)
+
+	client := NewClient("http://example.com/api/v1", "KALEIDO_API_KEY")
+	_, err := client.DeleteConfiguration("c1", "env1", "configuration1")
+	st.Expect(t, err, nil)
+	st.Expect(t, gock.IsDone(), true)
+}

--- a/kaleido/configuration_test.go
+++ b/kaleido/configuration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Kaleido, a ConsenSys business
+// Copyright 2020 Kaleido, a ConsenSys business
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kaleido/node.go
+++ b/kaleido/node.go
@@ -38,6 +38,11 @@ type Node struct {
 		RPC string `json:"rpc,omitempty"`
 		WSS string `json:"wss,omitempty"`
 	} `json:"urls,omitempty"`
+	OpsmetricID  string `json:"opsmetric_id,omitempty"`
+	NetworkingID string `json:"networking_id,omitempty"`
+	KmsID        string `json:"kms_id,omitempty"`
+	BackupID     string `json:"backup_id,omitempty"`
+	NodeConfigID string `json:"node_config_id,omitempty"`
 }
 
 func NewNode(name, membershipID, ezoneID string) Node {

--- a/kaleido/service.go
+++ b/kaleido/service.go
@@ -33,9 +33,10 @@ type Service struct {
 	State        string                 `json:"state,omitempty"`
 	Role         string                 `json:"role,omitempty"`
 	Urls         map[string]interface{} `json:"urls,omitempty"`
+	Details      map[string]interface{} `json:"details,omitempty"`
 }
 
-func NewService(name, service, membershipID string, zoneID string) Service {
+func NewService(name, service, membershipID string, zoneID string, details map[string]interface{}) Service {
 	return Service{
 		Name:         name,
 		Service:      service,
@@ -43,6 +44,7 @@ func NewService(name, service, membershipID string, zoneID string) Service {
 		ZoneID:       zoneID,
 		ID:           "",
 		State:        "",
+		Details:      details,
 	}
 }
 

--- a/kaleido/service_test.go
+++ b/kaleido/service_test.go
@@ -236,7 +236,7 @@ func TestServiceCreation(t *testing.T) {
 
 	t.Logf("Services: %v", services)
 
-	service := NewService("testService", serviceType, members[0].ID, zone.ID)
+	service := NewService("testService", serviceType, members[0].ID, zone.ID, nil)
 
 	res, err = client.CreateService(consortium.ID, env.ID, &service)
 


### PR DESCRIPTION
- Adds `configuration` to the SDK and `create` `list` `get` `delete` operations
- Allows `details` of both `configuration` and `service` to be set via a `--file` JSON file
- Allows `size` to be specified on `node` (noticed an omission here)
- Allows `kms-id` `opsmetric-id` `backup-id` `node-config-id` `networking-id` to be specified on a `node`

This groundwork in the SDK/CLI will also allow the terraform provider to be updated to support new service types and configurations.