### PR TITLE
change var names to match what is used on platform

### DIFF
--- a/kaleido/registry/org.go
+++ b/kaleido/registry/org.go
@@ -187,8 +187,8 @@ func (org *Organization) createSignedRequestForRegistration() (*SignedRequest, e
 	}
 
 	jsonBytes, err := json.Marshal(map[string]interface{}{
-		"envID":   org.Environment,
-		"memID":   org.MemberID,
+		"envId":   org.Environment,
+		"memId":   org.MemberID,
 		"nonce":   nonce,
 		"name":    registryName,
 		"proof":   string(proofPEM),


### PR DESCRIPTION
proofs use (`envId`, `memId`) instead of (`envID`, `memID`).
Without the changes users won't be able to establish external identity on on chain registry.