### PR TITLE
Add name field to app creds create command

### DIFF
--- a/cmd/appcreds.go
+++ b/cmd/appcreds.go
@@ -31,8 +31,10 @@ var appCredsCreateCmd = &cobra.Command{
 		validateEnvironmentID("appcreds")
 		validateMembershipID("appcreds")
 		client := getNewClient()
-		appcreds := kld.NewAppCreds(membershipID)
-		if name != "" {
+		var appcreds kld.AppCreds
+		if name == "" {
+			appcreds = kld.NewAppCreds(membershipID)
+		} else {
 			appcreds = kld.NewAppCredsWithName(membershipID, name)
 		}
 		res, err := client.CreateAppCreds(consortiumID, environmentID, &appcreds)

--- a/cmd/appcreds.go
+++ b/cmd/appcreds.go
@@ -32,7 +32,10 @@ var appCredsCreateCmd = &cobra.Command{
 		validateMembershipID("appcreds")
 		client := getNewClient()
 		appcreds := kld.NewAppCreds(membershipID)
-		res, err := client.CreateAppCreds(consortiumID, environmentID, name, &appcreds)
+		if name != "" {
+			appcreds = kld.NewAppCredsWithName(membershipID, name)
+		}
+		res, err := client.CreateAppCreds(consortiumID, environmentID, &appcreds)
 		validateCreationResponse(res, err, "appcreds")
 	},
 }

--- a/cmd/appcreds.go
+++ b/cmd/appcreds.go
@@ -32,7 +32,7 @@ var appCredsCreateCmd = &cobra.Command{
 		validateMembershipID("appcreds")
 		client := getNewClient()
 		appcreds := kld.NewAppCreds(membershipID)
-		res, err := client.CreateAppCreds(consortiumID, environmentID, &appcreds)
+		res, err := client.CreateAppCreds(consortiumID, environmentID, name, &appcreds)
 		validateCreationResponse(res, err, "appcreds")
 	},
 }
@@ -88,6 +88,7 @@ func newAppCredsCreateCmd() *cobra.Command {
 	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to to add the application credentials")
 	flags.StringVarP(&environmentID, "environment", "e", "", "ID of the environment to add the application credentials")
 	flags.StringVarP(&membershipID, "membership", "m", "", "ID of the membership to issue the application credentials to")
+	flags.StringVarP(&name, "name", "n", "", "Name of the application credential")
 	return appCredsCreateCmd
 }
 

--- a/kaleido/appcreds.go
+++ b/kaleido/appcreds.go
@@ -39,10 +39,14 @@ func NewAppCreds(membershipID string) AppCreds {
 	}
 }
 
-func (c *KaleidoClient) CreateAppCreds(consortiumID, envID, name string, appcreds *AppCreds) (*resty.Response, error) {
-	if name != "" {
-		appcreds.Name = name
+func NewAppCredsWithName(membershipID, name string) AppCreds {
+	return AppCreds{
+		MembershipID: membershipID,
+		Name:         name,
 	}
+}
+
+func (c *KaleidoClient) CreateAppCreds(consortiumID, envID string, appcreds *AppCreds) (*resty.Response, error) {
 	path := fmt.Sprintf(appcredsBasePath, consortiumID, envID)
 	return c.Client.R().SetBody(appcreds).SetResult(appcreds).Post(path)
 }

--- a/kaleido/appcreds.go
+++ b/kaleido/appcreds.go
@@ -22,6 +22,7 @@ import (
 
 type AppCreds struct {
 	MembershipID string `json:"membership_id"`
+	Name         string `json:"name,omitempty"`
 	AuthType     string `json:"auth_type,omitempty"`
 	Username     string `json:"username,omitempty"`
 	Password     string `json:"password,omitempty"`
@@ -38,7 +39,10 @@ func NewAppCreds(membershipID string) AppCreds {
 	}
 }
 
-func (c *KaleidoClient) CreateAppCreds(consortiumID, envID string, appcreds *AppCreds) (*resty.Response, error) {
+func (c *KaleidoClient) CreateAppCreds(consortiumID, envID, name string, appcreds *AppCreds) (*resty.Response, error) {
+	if name != "" {
+		appcreds.Name = name
+	}
 	path := fmt.Sprintf(appcredsBasePath, consortiumID, envID)
 	return c.Client.R().SetBody(appcreds).SetResult(appcreds).Post(path)
 }

--- a/kaleido/appcreds_test.go
+++ b/kaleido/appcreds_test.go
@@ -22,6 +22,10 @@ import (
 
 var mockAppCredCreatePayload = map[string]string{
 	"membership_id": "member1",
+}
+
+var mockAppCredCreateWithNamePayload = map[string]string{
+	"membership_id": "member1",
 	"name":          "testCred",
 }
 
@@ -48,7 +52,24 @@ func TestAppCredCreate(t *testing.T) {
 
 	client := NewClient("http://example.com/api/v1", "KALEIDO_API_KEY")
 	var appCreds = NewAppCreds("member1")
-	_, err := client.CreateAppCreds("c1", "env1", "testCred", &appCreds)
+	_, err := client.CreateAppCreds("c1", "env1", &appCreds)
+	st.Expect(t, err, nil)
+	st.Expect(t, gock.IsDone(), true)
+}
+
+func TestAppCredCreateWithName(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://example.com").
+		Post("/api/v1/consortia/c1/environments/env1/appcreds").
+		MatchType("json").
+		JSON(mockAppCredCreateWithNamePayload).
+		Reply(201).
+		JSON(mockAppCred)
+
+	client := NewClient("http://example.com/api/v1", "KALEIDO_API_KEY")
+	var appCreds = NewAppCredsWithName("member1", "testCred")
+	_, err := client.CreateAppCreds("c1", "env1", &appCreds)
 	st.Expect(t, err, nil)
 	st.Expect(t, gock.IsDone(), true)
 }

--- a/kaleido/appcreds_test.go
+++ b/kaleido/appcreds_test.go
@@ -22,10 +22,12 @@ import (
 
 var mockAppCredCreatePayload = map[string]string{
 	"membership_id": "member1",
+	"name":          "testCred",
 }
 
 var mockAppCred = map[string]string{
 	"membership_id": "zzzipxyjew",
+	"name":          "testCred",
 	"auth_type":     "basic_auth",
 	"_id":           "zzstcszriw",
 	"username":      "userid",
@@ -46,7 +48,7 @@ func TestAppCredCreate(t *testing.T) {
 
 	client := NewClient("http://example.com/api/v1", "KALEIDO_API_KEY")
 	var appCreds = NewAppCreds("member1")
-	_, err := client.CreateAppCreds("c1", "env1", &appCreds)
+	_, err := client.CreateAppCreds("c1", "env1", "testCred", &appCreds)
 	st.Expect(t, err, nil)
 	st.Expect(t, gock.IsDone(), true)
 }


### PR DESCRIPTION
Hello,

I added the app creds name field when creating a new app credential.

Need this in `terraform-provider-kaleido`