### PR TITLE
Add database type to node and add flag to create node command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ deps:
 build-linux:
 		GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BINARY_LIN) -v
 build-mac:
+		GOOS=darwin GOARCH=arm64 $(GOBUILD) -o $(BINARY_MAC) -v
+build-mac-legacy:
 		GOOS=darwin GOARCH=amd64 $(GOBUILD) -o $(BINARY_MAC) -v
 build-win:
 		GOOS=windows GOARCH=amd64 $(GOBUILD) -o $(BINARY_WIN) -v

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -123,14 +123,14 @@ func newEnvironmentListCmd() *cobra.Command {
 
 func newEnvironmentCreateCmd() *cobra.Command {
 	flags := environmentCreateCmd.Flags()
-	flags.StringVarP(&name, "name", "n", "", "Name of the consortium")
+	flags.StringVarP(&name, "name", "n", "", "Name of the environment")
 	flags.StringVarP(&desc, "desc", "d", "", "Short description of the purpose of the consortium")
 	flags.StringVarP(&consortiumID, "consortium", "c", "", "ID of the consortium to create the environment under")
 	flags.StringVarP(&provider, "provider", "p", "quorum", "underlying protocol to use for this network, quorum or geth")
 	flags.StringVarP(&consensus, "consensus", "k", "raft", "consensus algorithm to use for the given protocol, raft or ibft for quorum, poa for geth")
 	flags.BoolVarP(&multiRegion, "multi-region", "R", false, "whether to enable multi region")
 	flags.IntVarP(&blockPeriod, "block-period", "P", 0, "block period in seconds")
-	flags.UintVarP(&chainID, "chain-id", "h", 0, "Chain ID")
+	flags.UintVarP(&chainID, "chain-id", "C", 0, "Chain ID")
 	flags.StringArrayVarP(&accounts, "accounts", "a", []string{}, "Account addresses without 0x prefix - for pre-funded accounts")
 	flags.StringArrayVarP(&balances, "balances", "b", []string{}, "Account balances for addresses - for pre-funded accounts")
 

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -97,6 +97,7 @@ var nodeCreateCmd = &cobra.Command{
 		node.NetworkingID = networkingID
 		node.NodeConfigID = nodeConfigID
 		node.BafID = bafID
+		node.DatabaseType = databaseType
 
 		res, err := client.CreateNode(consortiumID, environmentID, &node)
 
@@ -161,7 +162,7 @@ func newNodeCreateCmd() *cobra.Command {
 	flags.StringVarP(&networkingID, "networking-id", "N", "", "Networking config ID to attach to the node")
 	flags.StringVarP(&nodeConfigID, "node-config-id", "C", "", "Node config ID to attach to the node")
 	flags.StringVarP(&bafID, "baf-id", "B", "", "Blockchain Application Firewall policy ID to attach to the node")
-
+	flags.StringVarP(&databaseType, "database-type", "d", "", "Only applicable to Corda nodes, the type of database for saving state data.")
 	return nodeCreateCmd
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,6 +64,7 @@ var configID string
 var accounts []string
 var balances []string
 var channelID string
+var databaseType string
 
 // for delete command
 var deleteID string

--- a/kaleido/node.go
+++ b/kaleido/node.go
@@ -44,6 +44,7 @@ type Node struct {
 	BafID                string                 `json:"baf_id,omitempty"`
 	HybridPortAllocation int64                  `json:"hybrid_port_allocation,omitempty"`
 	NodeIdentity         string                 `json:"node_identity_data,omitempty"`
+	DatabaseType         string                 `json:"database_type,omitempty"`
 }
 
 func NewNode(name, membershipID, ezoneID string) Node {


### PR DESCRIPTION
- Add database_type as a flag to pass in for creating a new node 
- Change description for create environment to specify name as name of environment 
- change chainId flag to be 'C' instead of 'h' due to issue with --help flag 
- Add build option for apple silicon 